### PR TITLE
Congressional Apportionment Amendment

### DIFF
--- a/Constitution.md
+++ b/Constitution.md
@@ -54,11 +54,7 @@ Enumeration shall be made within three Years after the first Meeting of the
 Congress of the United States, and within every subsequent Term of ten Years,
 in such Manner as they shall by Law direct. The Number of Representatives shall
 not exceed one for every thirty Thousand, but each State shall have at Least
-one Representative; and until such enumeration shall be made, the State of New
-Hampshire shall be entitled to chuse three, Massachusetts eight, Rhode-Island
-and Providence Plantations one, Connecticut five, New-York six, New Jersey
-four, Pennsylvania eight, Delaware one, Maryland six, Virginia ten, North
-Carolina five, South Carolina five, and Georgia three.
+one Representative.
 
 When vacancies happen in the Representation from any State, the Executive
 Authority thereof shall issue Writs of Election to fill such Vacancies.

--- a/Constitution.md
+++ b/Constitution.md
@@ -54,7 +54,13 @@ Enumeration shall be made within three Years after the first Meeting of the
 Congress of the United States, and within every subsequent Term of ten Years,
 in such Manner as they shall by Law direct. The Number of Representatives shall
 not exceed one for every thirty Thousand, but each State shall have at Least
-one Representative.
+one Representative, until the number shall amount to one hundred, after which
+the proportion shall be so regulated by Congress, that there shall be not less
+than one hundred Representatives, nor less than one Representative for every
+forty thousand persons, until the number of Representatives shall amount to two
+hundred, after which the proportion shall be so regulated by Congress, that
+there shall not be less than two hundred Representatives, nor more than one
+Representative for every fifty thousand persons.
 
 When vacancies happen in the Representation from any State, the Executive
 Authority thereof shall issue Writs of Election to fill such Vacancies.

--- a/amendments/congressionalApportionment.md
+++ b/amendments/congressionalApportionment.md
@@ -1,0 +1,13 @@
+# Amendments to the Constitution of the United States of America
+
+## Amendment Proposal Congressional Apportionment
+
+After the first enumeration required by the first article of the Constitution,
+there shall be one Representative for every thirty thousand, until the number
+shall amount to one hundred, after which the proportion shall be so regulated
+by Congress, that there shall be not less than one hundred Representatives, nor
+less than one Representative for every forty thousand persons, until the number
+of Representatives shall amount to two hundred, after which the proportion
+shall be so regulated by Congress, that there shall not be less than two
+hundred Representatives, nor more than one Representative for every fifty
+thousand persons.


### PR DESCRIPTION
Author: Congress
Date: September 25, 1789

With 50 states, 27 additional ratifications are necessary to reach the required threshold

Having been approved by Congress, the twelve Bill of Rights amendments
were sent to the states for ratification. This proposed amendment was
the first listed of the twelve and was ratified by the legislatures of
the following states:

* New Jersey: November 20, 1789
* Maryland: December 19, 1789
* North Carolina: December 22, 1789
* South Carolina: January 19, 1790
* New Hampshire: January 25, 1790
* New York: February 24, 1790
* Rhode Island: June 7, 1790
* Pennsylvania: September 21, 1791 (after rejecting it on March 10, 1790)
* Virginia: November 3, 1791
* Vermont: November 3, 1791
* Kentucky: June 27, 1792

-- https://en.wikipedia.org/wiki/Congressional_Apportionment_Amendment